### PR TITLE
feat: implement stateless JWT authentication (#36)

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -5,6 +5,7 @@ DATABASE_URL=postgres://username:password@localhost:5432/whiteboard
 HOST=127.0.0.1
 PORT=8080
 CORS_ALLOWED_ORIGIN=http://localhost:4200
+JWT_SECRET=your-super-secret-jwt-key-change-this-in-production
 
 # Logging Configuration
-RUST_LOG=info a
+RUST_LOG=info

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,3 +14,5 @@ actix-cors = "0.6"
 async-trait = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+jsonwebtoken = "8"
+bcrypt = "0.15"

--- a/backend/migrations/002_add_password_hash.sql
+++ b/backend/migrations/002_add_password_hash.sql
@@ -1,0 +1,4 @@
+-- Migration: Add password_hash column to users table for authentication
+-- Run this SQL to add password hashing support
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash VARCHAR(255) NOT NULL DEFAULT '';

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -6,8 +6,11 @@ use actix_cors::Cors;
 use actix_web::{http::header, web, App, HttpServer, Responder, HttpResponse, post, get};
 use actix_web::middleware::{DefaultHeaders, Logger};
 use actix_web::web::Data;
+use actix_web::HttpRequest;
+use bcrypt::{hash, verify, DEFAULT_COST};
 use chrono::{DateTime, Utc};
 use dotenv::dotenv;
+use jsonwebtoken::{encode, decode, Header, Algorithm, Validation, EncodingKey, DecodingKey, errors::Error as JwtError};
 use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, postgres::PgPoolOptions};
 use std::env;
@@ -90,6 +93,42 @@ fn build_cors() -> Cors {
         .expose_headers([header::LINK])
         .supports_credentials()
         .max_age(3600)
+}
+
+fn generate_jwt(user_id: &str) -> Result<String, JwtError> {
+    let jwt_secret = env::var("JWT_SECRET").unwrap_or_else(|_| "default_secret".to_string());
+    let expiration = Utc::now()
+        .checked_add_signed(chrono::Duration::hours(24))
+        .expect("valid timestamp")
+        .timestamp() as usize;
+
+    let claims = Claims {
+        sub: user_id.to_owned(),
+        exp: expiration,
+        iat: Utc::now().timestamp() as usize,
+    };
+
+    encode(&Header::default(), &claims, &EncodingKey::from_secret(jwt_secret.as_ref()))
+}
+
+fn validate_jwt(token: &str) -> Result<Claims, JwtError> {
+    let jwt_secret = env::var("JWT_SECRET").unwrap_or_else(|_| "default_secret".to_string());
+    let validation = Validation::new(Algorithm::HS256);
+
+    let token_data = decode::<Claims>(token, &DecodingKey::from_secret(jwt_secret.as_ref()), &validation)?;
+    Ok(token_data.claims)
+}
+
+async fn extract_user_id_from_request(req: &HttpRequest, state: &Data<AppState>) -> Result<String, AppError> {
+    let auth_header = req.headers().get("Authorization")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|h| h.strip_prefix("Bearer "))
+        .ok_or_else(|| AppError::ValidationError("Missing or invalid Authorization header".to_string()))?;
+
+    let claims = validate_jwt(auth_header)
+        .map_err(|_| AppError::ValidationError("Invalid token".to_string()))?;
+
+    Ok(claims.sub)
 }
 
 #[get("/health")]
@@ -223,6 +262,85 @@ async fn get_migration_status_endpoint(state: Data<AppState>) -> Result<impl Res
     Ok(HttpResponse::Ok().json(status))
 }
 
+#[post("/auth/register")]
+async fn register(state: Data<AppState>, req: web::Json<RegisterRequest>) -> Result<impl Responder, AppError> {
+    // Validate input
+    if req.email.trim().is_empty() || req.name.trim().is_empty() || req.password.len() < 6 {
+        return Err(AppError::ValidationError("Invalid registration data".to_string()));
+    }
+
+    let repo = state.repositories.user_repository();
+
+    // Check if user already exists
+    if repo.find_by_email(&req.email).await
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?
+        .is_some() {
+        return Err(AppError::ValidationError("User already exists".to_string()));
+    }
+
+    // Hash password
+    let password_hash = hash(&req.password, DEFAULT_COST)
+        .map_err(|_| AppError::InternalError("Failed to hash password".to_string()))?;
+
+    // Create user
+    let db_user = repo.create_user(&req.email, &req.name, &password_hash).await
+        .map_err(|e| AppError::InternalError(format!("Failed to create user: {}", e)))?;
+
+    let user = User::from(db_user);
+    let token = generate_jwt(&user.id)
+        .map_err(|_| AppError::InternalError("Failed to generate token".to_string()))?;
+
+    let expires_at = (Utc::now() + chrono::Duration::hours(24)).timestamp() as u64;
+
+    Ok(HttpResponse::Created().json(AuthResponse {
+        user,
+        token,
+        expires_at,
+    }))
+}
+
+#[post("/auth/login")]
+async fn login(state: Data<AppState>, req: web::Json<LoginRequest>) -> Result<impl Responder, AppError> {
+    let repo = state.repositories.user_repository();
+
+    // Find user by email
+    let db_user = repo.find_by_email(&req.email).await
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?
+        .ok_or_else(|| AppError::ValidationError("Invalid credentials".to_string()))?;
+
+    // Verify password
+    if !verify(&req.password, &db_user.password_hash)
+        .map_err(|_| AppError::InternalError("Failed to verify password".to_string()))? {
+        return Err(AppError::ValidationError("Invalid credentials".to_string()));
+    }
+
+    let user = User::from(db_user);
+    let token = generate_jwt(&user.id)
+        .map_err(|_| AppError::InternalError("Failed to generate token".to_string()))?;
+
+    let expires_at = (Utc::now() + chrono::Duration::hours(24)).timestamp() as u64;
+
+    Ok(HttpResponse::Ok().json(AuthResponse {
+        user,
+        token,
+        expires_at,
+    }))
+}
+
+#[get("/auth/me")]
+async fn get_me(req: HttpRequest, state: Data<AppState>) -> Result<impl Responder, AppError> {
+    let user_id = extract_user_id_from_request(&req, &state).await?;
+    let uuid = sqlx::types::Uuid::parse_str(&user_id)
+        .map_err(|_| AppError::ValidationError("Invalid user ID".to_string()))?;
+
+    let repo = state.repositories.user_repository();
+    let db_user = repo.find_by_id(uuid).await
+        .map_err(|e| AppError::InternalError(format!("Database error: {}", e)))?
+        .ok_or_else(|| AppError::NotFound("User not found".to_string()))?;
+
+    Ok(HttpResponse::Ok().json(User::from(db_user)))
+}
+
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv().ok();
@@ -233,32 +351,18 @@ async fn main() -> std::io::Result<()> {
 
     println!("Starting server at http://{}", addr);
 
-<<<<<<< HEAD
     let database_url = env::var("DATABASE_URL")
         .unwrap_or_else(|_| "postgres://postgres:postgres@localhost/whiteboard".to_string());
-=======
-    // Set up database connection
-    let database_url = env::var("DATABASE_URL")
-        .unwrap_or_else(|_| "postgres://postgres:password@localhost/whiteboard".to_string());
->>>>>>> aa9ae66b088cc8e9f6e30de269beaad9828bcb4d
 
     let db = PgPoolOptions::new()
         .max_connections(5)
         .connect(&database_url)
         .await
-<<<<<<< HEAD
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to connect to database: {}", e)))?;
 
     run_migrations(&db)
         .await
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to run migrations: {}", e)))?;
-=======
-        .expect("Failed to connect to database");
-
-    println!("Connected to database");
-
-    // Run database migrations
-    println!("Running database migrations...");
     run_migrations(&db).await.expect("Failed to run migrations");
     println!("Migrations completed successfully");
 >>>>>>> aa9ae66b088cc8e9f6e30de269beaad9828bcb4d
@@ -281,6 +385,9 @@ async fn main() -> std::io::Result<()> {
             .wrap(Logger::default())
             .service(health)
             .service(get_state)
+            .service(register)
+            .service(login)
+            .service(get_me)
             .service(add_draw)
             .service(add_draw_batch)
             .service(get_boards)

--- a/backend/src/models.rs
+++ b/backend/src/models.rs
@@ -18,6 +18,7 @@ pub struct DbUser {
     pub id: Uuid,
     pub email: String,
     pub name: String,
+    pub password_hash: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -49,6 +50,7 @@ impl From<User> for DbUser {
             id: Uuid::parse_str(&user.id).unwrap_or_else(|_| Uuid::new_v4()),
             email: user.email,
             name: user.name,
+            password_hash: "".to_string(), // Placeholder, will be set during registration
             created_at,
             updated_at,
         }
@@ -187,6 +189,33 @@ pub struct ApiResponse<T> {
     pub data: Option<T>,
     pub error: Option<String>,
     pub timestamp: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Claims {
+    pub sub: String, // user id
+    pub exp: usize,  // expiration time
+    pub iat: usize,  // issued at
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct LoginRequest {
+    pub email: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RegisterRequest {
+    pub email: String,
+    pub name: String,
+    pub password: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AuthResponse {
+    pub user: User,
+    pub token: String,
+    pub expires_at: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]

--- a/backend/src/repository.rs
+++ b/backend/src/repository.rs
@@ -30,7 +30,7 @@ impl Repository<DbUser, sqlx::types::Uuid> for UserRepository {
     async fn find_by_id(&self, id: sqlx::types::Uuid) -> Result<Option<DbUser>> {
         sqlx::query_as!(
             DbUser,
-            "SELECT id, email, name, created_at, updated_at FROM users WHERE id = $1",
+            "SELECT id, email, name, password_hash, created_at, updated_at FROM users WHERE id = $1",
             id
         )
         .fetch_optional(&self.pool)
@@ -40,7 +40,7 @@ impl Repository<DbUser, sqlx::types::Uuid> for UserRepository {
     async fn find_all(&self) -> Result<Vec<DbUser>> {
         sqlx::query_as!(
             DbUser,
-            "SELECT id, email, name, created_at, updated_at FROM users ORDER BY created_at DESC"
+            "SELECT id, email, name, password_hash, created_at, updated_at FROM users ORDER BY created_at DESC"
         )
         .fetch_all(&self.pool)
         .await
@@ -50,13 +50,14 @@ impl Repository<DbUser, sqlx::types::Uuid> for UserRepository {
         sqlx::query_as!(
             DbUser,
             r#"
-            INSERT INTO users (id, email, name, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5)
-            RETURNING id, email, name, created_at, updated_at
+            INSERT INTO users (id, email, name, password_hash, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, email, name, password_hash, created_at, updated_at
             "#,
             user.id,
             user.email,
             user.name,
+            user.password_hash,
             user.created_at,
             user.updated_at
         )
@@ -69,13 +70,14 @@ impl Repository<DbUser, sqlx::types::Uuid> for UserRepository {
             DbUser,
             r#"
             UPDATE users
-            SET email = $2, name = $3, updated_at = $4
+            SET email = $2, name = $3, password_hash = $4, updated_at = $5
             WHERE id = $1
-            RETURNING id, email, name, created_at, updated_at
+            RETURNING id, email, name, password_hash, created_at, updated_at
             "#,
             user.id,
             user.email,
             user.name,
+            user.password_hash,
             user.updated_at
         )
         .fetch_one(&self.pool)
@@ -101,10 +103,32 @@ impl UserRepository {
     pub async fn find_by_email(&self, email: &str) -> Result<Option<DbUser>> {
         sqlx::query_as!(
             DbUser,
-            "SELECT id, email, name, created_at, updated_at FROM users WHERE email = $1",
+            "SELECT id, email, name, password_hash, created_at, updated_at FROM users WHERE email = $1",
             email
         )
         .fetch_optional(&self.pool)
+        .await
+    }
+
+    pub async fn create_user(&self, email: &str, name: &str, password_hash: &str) -> Result<DbUser> {
+        let now = chrono::Utc::now();
+        let user_id = sqlx::types::Uuid::new_v4();
+
+        sqlx::query_as!(
+            DbUser,
+            r#"
+            INSERT INTO users (id, email, name, password_hash, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            RETURNING id, email, name, password_hash, created_at, updated_at
+            "#,
+            user_id,
+            email,
+            name,
+            password_hash,
+            now,
+            now
+        )
+        .fetch_one(&self.pool)
         .await
     }
 }


### PR DESCRIPTION
- Add JWT dependencies (jsonwebtoken, bcrypt)
- Update user models with password_hash field
- Implement JWT token generation and validation
- Add auth endpoints: /auth/register, /auth/login, /auth/me
- Add database migration for password_hash column
- Configure JWT secret in environment
- Update repository methods for user authentication